### PR TITLE
Fix address validation logic in shipping rate validator

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-rates-validator.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-rates-validator.js
@@ -62,7 +62,7 @@ define([
          * @return {Boolean}
          */
         validateAddressData: function (address) {
-            return validators.some(function (validator) {
+            return validators.every(function (validator) {
                 return validator.validate(address);
             });
         },


### PR DESCRIPTION
### Description (*)
The address validation logic in the shipping rate validator is broken: it incorrectly passes if any rule succeeds, rather than requiring that all necessary conditions be met. This can cause significant checkout problems under certain circumstances.

### Fixed Issues (if relevant)
1. Fixes magento/magento2#39039

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
