### PR TITLE
Fix the product gallery tab when an image attribute label contains a single quote

### DIFF
--- a/app/code/Magento/ProductVideo/view/adminhtml/templates/helper/gallery.phtml
+++ b/app/code/Magento/ProductVideo/view/adminhtml/templates/helper/gallery.phtml
@@ -52,7 +52,7 @@ $elementToggleCode = $element->getToggleCode() ? $element->getToggleCode() :
      data-mage-init='{"openVideoModal":{}}'
      data-parent-component="<?= $escaper->escapeHtml($block->getData('config/parentComponent')) ?>"
      data-images="<?= $escaper->escapeHtmlAttr($imagesJson) ?>"
-     data-types='<?= /* @noEscape */ $jsonHelper->jsonEncode($block->getImageTypes()) ?>'
+     data-types="<?= $block->escapeHtmlAttr($jsonHelper->jsonEncode($block->getImageTypes())) ?>"
 >
     <?php if (!$block->getElement()->getReadonly() && $isEditEnabled): ?>
         <div class="image image-placeholder">


### PR DESCRIPTION
### Description (*)

The `data-types` attribute in the admin product gallery uses single-quoted HTML delimiter with `@noEscape`. When an image attribute label contains a single quote (e.g. `Image d'exemple`), the attribute is cut off and the gallery breaks.

Fix: use `escapeHtmlAttr()` with double quotes, consistent with `data-images` on the line above.

Introduced in 17f0f4d8 (MAGETWO-99285), where `escapeHtml()` was replaced with `@noEscape` instead of `escapeHtmlAttr()`.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)

1. Fixes magento/magento2#16807

### Manual testing scenarios (*)

1. Create an image attribute with a label containing a single quote (e.g. `Image d'exemple`)
2. Assign it to some attribute set
3. Edit any corresponding product in the admin and open the gallery tab: the gallery is broken

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
